### PR TITLE
Specify runtime dependencies

### DIFF
--- a/camunda.gemspec
+++ b/camunda.gemspec
@@ -30,8 +30,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activeresource", "~> 5.0"
+  
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "activeresource", "~> 5.0"
 end

--- a/lib/camunda.rb
+++ b/lib/camunda.rb
@@ -1,4 +1,4 @@
-require 'activesupport'
+require 'activeresource'
 
 module Camunda
 end

--- a/lib/camunda.rb
+++ b/lib/camunda.rb
@@ -1,3 +1,5 @@
+require 'activesupport'
+
 module Camunda
 end
 


### PR DESCRIPTION
activeresource is a runtime dependency for this gem and necessary.

If not specified including this gem in a rails application will fail (if activeresource is not in the app Gemfile by chance).