### PR TITLE
Allow activeresource 5.1 (needed for Rails 6).

### DIFF
--- a/camunda.gemspec
+++ b/camunda.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activeresource", "~> 5.0"
+  spec.add_dependency "activeresource", [">= 5.0", "< 6"]
   
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Allow activeresource 5.1 (needed for Rails 6).